### PR TITLE
change protocol for bootstrap.css from http to https

### DIFF
--- a/resume.template
+++ b/resume.template
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{basics.firstName}} {{basics.lastName}}</title>
-    <link rel="stylesheet" href="http://bootswatch.com/journal/bootstrap.css" type="text/css" />
+    <link rel="stylesheet" href="https://bootswatch.com/journal/bootstrap.css" type="text/css" />
 
    <style>
 


### PR DESCRIPTION
# Expected behavior
- we can see the resume with https

# Actual behavior
- the style is not loaded when we see bia https

# Others

# URL

## should be https when we can use it
https://google.github.io/styleguide/htmlcssguide.html#Protocol

## we can see bootstrap.css bia https
https://bootswatch.com/journal/bootstrap.css